### PR TITLE
Support TST 3.0.12 and later

### DIFF
--- a/background.js
+++ b/background.js
@@ -127,7 +127,7 @@ async function registerToTST() {
       await browser.runtime.sendMessage(TST_ID, {
         type: "register-self",
         name: self.id,
-        listeningTypes: ["ready", "sidebar-show"],
+        listeningTypes: ["ready", "sidebar-show", "permissions-changed"],
       });
     } catch(e) {
       // Could not register
@@ -149,6 +149,7 @@ async function handleTSTMessage(message, sender) {
         case "ready":
           registerToTST();
         case "sidebar-show":
+        case "permissions-changed":
           if(ColoredTabs.state.inited != true) {
 //             console.log('TST ready, initializing ColoredTabs');
             ColoredTabs.init();


### PR DESCRIPTION
On TST 3.0.12 and later, TST don't send notification messages about private windows by default, and a `permissions-changed` message is delivered when the user allows your addon to receive notifications from private windows. I think that these changes should make this addon compatible to TST 3.0.12 and later.

For more details, please see the updated API document:
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#information-in-private-windows
https://github.com/piroor/treestyletab/wiki/API-for-other-addons#when-permissions-for-your-addon-are-changed