### PR TITLE
Defines CSS variables, to set background-color and provide reliable inheritance.

### DIFF
--- a/background.js
+++ b/background.js
@@ -105,7 +105,20 @@ var ColoredTabs = {
 
     for(let i = 0; i < 360; i += (360 / ColoredTabs.settings.colors)) {
       let hue = Math.round(i);
-      css += `.tab.coloredTabsHue` + hue + ` {background-color: hsl(` + hue + `,` + ColoredTabs.settings.saturation + `%,` + ColoredTabs.settings.lightness + `%);}`;
+
+      css += `
+.tab.coloredTabsHue${hue} {
+  --tst-color-tabs-bg-hue: ${hue};
+  --tst-color-tabs-bg-saturation: ${ColoredTabs.settings.saturation}%;
+  --tst-color-tabs-bg-lightness: ${ColoredTabs.settings.lightness}%;
+  --tst-color-tabs-bg-color: hsl(
+    var(--tst-colortabs-bg-hue), 
+    var(--tst-color-tabs-bg-saturation),
+    var(--tst-color-tabs-bg-lightness)
+  );
+
+  background-color: var(--tst-color-tabs-bg-color);
+}`;
     }
 
     if(ColoredTabs.state.hostsMatchColor !== undefined) {

--- a/background.js
+++ b/background.js
@@ -112,7 +112,7 @@ var ColoredTabs = {
   --tst-color-tabs-bg-saturation: ${ColoredTabs.settings.saturation}%;
   --tst-color-tabs-bg-lightness: ${ColoredTabs.settings.lightness}%;
   --tst-color-tabs-bg-color: hsl(
-    var(--tst-colortabs-bg-hue), 
+    var(--tst-color-tabs-bg-hue), 
     var(--tst-color-tabs-bg-saturation),
     var(--tst-color-tabs-bg-lightness)
   );


### PR DESCRIPTION
An implementation of the feature suggestion I posted - #20 _Store background-color value in a CSS variable, for responsive styling._

Intends to allow a tab's child elements to be styled **more** responsively to a tab's background colour.

CSS variables added:
* Hue,              --tst-color-tabs-bg-hue
* Saturation,       --tst-color-tabs-bg-saturation
* Lightness,        --tst-color-tabs-bg-lightness
* Background-color, --tst-color-tabs-bg-color